### PR TITLE
Add basic postfix client (default) & server recipes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,3 +3,6 @@ suites:
   - name: default
     run_list:
       - recipe[osl-postfix::default]
+  - name: server
+    run_list:
+      - recipe[osl-postfix::server]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,15 @@
 osl-postfix Cookbook
 ====================
-TODO: Enter the cookbook description here.
-
-e.g.
-This cookbook makes your favorite breakfast sandwich.
+This cookbook is a wrapper around [postfix](https://github.com/chef-cookbooks/postfix).
 
 Requirements
 ------------
-TODO: List your cookbook requirements. Be sure to include any
-requirements this cookbook has on platforms, libraries, other cookbooks,
-packages, operating systems, etc.
 
-e.g.
-#### packages
-- `toaster` - osl-postfix needs toaster to brown your bagel.
+#### Platforms
+- CentOS 7
+
+#### Cookbooks
+- [`postfix`](https://github.com/chef-cookbooks/postfix) - the upstream cookbook that `osl-postfix` wraps
 
 Attributes
 ----------

--- a/Rakefile
+++ b/Rakefile
@@ -26,10 +26,10 @@ end
 #
 def gen_ssl_cert
   name = OpenSSL::X509::Name.new [
-    ['C', 'US'],
-    ['ST', 'Oregon'],
+    %w(C US),
+    %w(ST Oregon),
     ['CN', 'OSU Open Source Lab'],
-    ['DC', 'example']
+    %w(DC example),
   ]
   key = OpenSSL::PKey::RSA.new 2048
 
@@ -45,7 +45,7 @@ def gen_ssl_cert
   cert.issuer = name
   cert.sign(key, OpenSSL::Digest::SHA1.new)
 
-  return cert, key
+  [cert, key]
 end
 
 ##
@@ -88,7 +88,7 @@ directory 'test/integration/data_bags/certificates' => 'test/integration'
 #
 file snakeoil_file_path => [
   'test/integration/data_bags/certificates',
-  'test/integration/encrypted_data_bag_secret'
+  'test/integration/encrypted_data_bag_secret',
 ] do
 
   encrypted_data_bag_secret = Chef::EncryptedDataBagItem.load_secret(
@@ -110,19 +110,20 @@ task snakeoil: snakeoil_file_path
 desc 'Create an Encrypted Databag Secret'
 task secret_file: encrypted_data_bag_secret_path
 
-require 'rubocop/rake_task'
-desc 'Run RuboCop (style) tests'
-RuboCop::RakeTask.new(:style)
+desc 'Run RuboCop (cookstyle) tests'
+task :style do
+  run_command('cookstyle')
+end
 
 desc 'Run FoodCritic (lint) tests'
 task :lint do
-    run_command('foodcritic --epic-fail any .')
+  run_command('foodcritic --epic-fail any .')
 end
 
 desc 'Run RSpec (unit) tests'
 task :unit do
-    run_command('rm -f Berksfile.lock')
-    run_command('rspec')
+  run_command('rm -f Berksfile.lock')
+  run_command('rspec')
 end
 
 desc 'Run all tests'

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,11 @@ description      'Installs/Configures osl-postfix'
 long_description 'Installs/Configures osl-postfix'
 version          '0.1.0'
 
+depends          'apt'
 depends          'postfix', '~> 5.3.0'
 
+supports         'centos', '~> 6.0'
 supports         'centos', '~> 7.0'
+supports         'debian', '~> 8.0'
+supports         'debian', '~> 9.0'
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,6 @@ description      'Installs/Configures osl-postfix'
 long_description 'Installs/Configures osl-postfix'
 version          '0.1.0'
 
-depends          'postfix'
+depends          'postfix', '~> 5.3.0'
 
 supports         'centos', '~> 7.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,11 +1,14 @@
 name             'osl-postfix'
 maintainer       'Oregon State University'
 maintainer_email 'chef@osuosl.org'
-license          'apachev2'
+license          'Apache-2.0'
+chef_version     '>= 12.18' if respond_to?(:chef_version)
 issues_url       'https://github.com/osuosl-cookbooks/osl-postfix/issues'
 source_url       'https://github.com/osuosl-cookbooks/osl-postfix'
 description      'Installs/Configures osl-postfix'
 long_description 'Installs/Configures osl-postfix'
 version          '0.1.0'
+
+depends          'postfix'
 
 supports         'centos', '~> 7.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,9 @@ case node['network']['default_gateway']
 when '10.162.136.1', '128.193.126.193', '148.100.110.1'
   node.default['postfix']['main']['relayhost'] = '[smtp.osuosl.org]:587'
   node.default['postfix']['main']['smtp_use_tls'] = 'yes'
+  if node['platform_family'] == 'debian'
+    node.default['postfix']['main']['smtp_tls_CAfile'] = '/etc/ssl/certs/ca-certificates.crt'
+  end
 else
   node.default['postfix']['main']['relayhost'] = '[smtp.osuosl.org]:25'
   node.default['postfix']['main']['smtp_use_tls'] = 'no'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,3 +16,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+node.default['postfix']['mail_type'] = 'client'
+node.default['postfix']['main']['myorigin'] = '$mydomain'
+node.default['postfix']['main']['smtpd_use_tls'] = 'no'
+
+case node['network']['default_gateway']
+# We must use the submission port on these networks
+when '10.162.136.1', '128.193.126.193', '148.100.110.1'
+  node.default['postfix']['main']['relayhost'] = '[smtp.osuosl.org]:587'
+  node.default['postfix']['main']['smtp_use_tls'] = 'yes'
+else
+  node.default['postfix']['main']['relayhost'] = '[smtp.osuosl.org]:25'
+  node.default['postfix']['main']['smtp_use_tls'] = 'no'
+end
+
+include_recipe 'postfix'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,0 +1,19 @@
+#
+# Cookbook:: osl-postfix
+# Recipe:: server
+#
+# Copyright:: 2018, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_recipe 'postfix::server'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,23 +5,23 @@ ChefSpec::Coverage.start! { add_filter 'osl-postfix' }
 
 CENTOS_7 = {
   platform: 'centos',
-  version: '7.2.1511'
+  version: '7.2.1511',
 }.freeze
 
 CENTOS_6 = {
   platform: 'centos',
-  version: '6.7'
+  version: '6.8',
 }.freeze
 
 DEBIAN_8 = {
   platform: 'debian',
-  version: '8.4'
+  version: '8.6',
 }.freeze
 
 ALL_PLATFORMS = [
   CENTOS_6,
   CENTOS_7,
-  DEBIAN_8
+  DEBIAN_8,
 ].freeze
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,3 +27,9 @@ ALL_PLATFORMS = [
 RSpec.configure do |config|
   config.log_level = :fatal
 end
+
+shared_context 'common_stubs' do
+  before do
+    stub_command('/usr/bin/test /etc/alternatives/mta -ef /usr/sbin/sendmail.postfix')
+  end
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -37,6 +37,13 @@ describe 'osl-postfix::default' do
             expect(chef_run).to render_file('/etc/postfix/main.cf').with_content(line)
           end
         end
+        it do
+          if p == DEBIAN_8
+            expect(chef_run).to render_file('/etc/postfix/main.cf').with_content('smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt')
+          else
+            expect(chef_run).to_not render_file('/etc/postfix/main.cf').with_content('smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt')
+          end
+        end
       end
       it do
         expect(chef_run).to include_recipe 'postfix'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -6,9 +6,9 @@ describe 'osl-postfix::default' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
-      before do
-        stub_command('/usr/bin/test /etc/alternatives/mta -ef /usr/sbin/sendmail.postfix')
-      end
+
+      include_context 'common_stubs'
+
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -6,8 +6,40 @@ describe 'osl-postfix::default' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
+      before do
+        stub_command('/usr/bin/test /etc/alternatives/mta -ef /usr/sbin/sendmail.postfix')
+      end
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
+      end
+      [
+        '# Configured as client',
+        'myorigin = $mydomain',
+        'relayhost = [smtp.osuosl.org]:25',
+        'smtpd_use_tls = no',
+        'smtp_use_tls = no',
+      ].each do |line|
+        it do
+          expect(chef_run).to render_file('/etc/postfix/main.cf').with_content(line)
+        end
+      end
+      context 'postfix submission port' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p) do |node|
+            node.automatic['network']['default_gateway'] = '10.162.136.1'
+          end.converge(described_recipe)
+        end
+        [
+          'relayhost = [smtp.osuosl.org]:587',
+          'smtp_use_tls = yes',
+        ].each do |line|
+          it do
+            expect(chef_run).to render_file('/etc/postfix/main.cf').with_content(line)
+          end
+        end
+      end
+      it do
+        expect(chef_run).to include_recipe 'postfix'
       end
     end
   end

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../spec_helper'
+
+describe 'osl-postfix::server' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+
+      include_context 'common_stubs'
+
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+
+      it do
+        expect(chef_run).to include_recipe 'postfix::server'
+      end
+
+      it do
+        expect(chef_run).to render_file('/etc/postfix/main.cf').with_content(/# Configured as master/)
+      end
+    end
+  end
+end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -1,3 +1,28 @@
 require 'serverspec'
 
 set :backend, :exec
+
+describe service 'postfix' do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe port 25 do
+  it { should be_listening }
+end
+
+describe package 'postfix' do
+  it { should be_installed }
+end
+
+describe file('/etc/postfix/main.cf') do
+  [
+    '# Configured as client',
+    /myorigin = \$mydomain/,
+    'relayhost = \[smtp.osuosl.org\]:25',
+    'smtpd_use_tls = no',
+    'smtp_use_tls = no',
+  ].each do |line|
+    its(:content) { should match(line) }
+  end
+end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -1,21 +1,10 @@
-require 'serverspec'
+require 'spec_helper'
 
-set :backend, :exec
-
-describe service 'postfix' do
-  it { should be_enabled }
-  it { should be_running }
+describe 'postfix' do
+  it_behaves_like 'postfix'
 end
 
-describe port 25 do
-  it { should be_listening }
-end
-
-describe package 'postfix' do
-  it { should be_installed }
-end
-
-describe file('/etc/postfix/main.cf') do
+describe file '/etc/postfix/main.cf' do
   [
     '# Configured as client',
     /myorigin = \$mydomain/,

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -15,3 +15,8 @@ describe file '/etc/postfix/main.cf' do
     its(:content) { should match(line) }
   end
 end
+
+describe file '/etc/ssl/certs/ca-certificates.crt' do
+  it { should be_file }   if os[:family] == 'debian'
+  it { should_not exist } if os[:family] != 'debian'
+end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,18 @@
+require 'serverspec'
+
+set :backend, :exec
+
+shared_examples_for 'postfix' do
+  describe service 'postfix' do
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  describe port 25 do
+    it { should be_listening }
+  end
+
+  describe package 'postfix' do
+    it { should be_installed }
+  end
+end

--- a/test/integration/server/serverspec/server_spec.rb
+++ b/test/integration/server/serverspec/server_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'postfix' do
+  it_behaves_like 'postfix'
+end
+
+describe file '/etc/postfix/main.cf' do
+  its(:content) { should match(/# Configured as master/) }
+end


### PR DESCRIPTION
This is a wrapper cookbook for `postfix`. This PR adds in the postfix configuration currently found in `base::default` along with the tests associated with it. It also wraps `postfix::server` for non-client configurations.

It adds Chef 13 support too (`code_generator` still generates for 12).