### PR TITLE
Add node['osl-postfix']['main'] which sets node['postfix']['main']

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ Requirements
 
 Attributes
 ----------
-TODO: List your cookbook attributes here.
-
-e.g.
-#### osl-postfix::default
 <table>
   <tr>
     <th>Key</th>
@@ -25,29 +21,22 @@ e.g.
     <th>Default</th>
   </tr>
   <tr>
-    <td><tt>['osl-postfix']['bacon']</tt></td>
-    <td>Boolean</td>
-    <td>whether to include bacon</td>
-    <td><tt>true</tt></td>
+    <td><tt>['osl-postfix']['main']</tt></td>
+    <td>Hash</td>
+    <td>Set attributes for <tt>['postfix']['main']</tt> here and they'll be set in <tt>osl-postfix::attributes</tt></td>
+    <td><tt>{}</tt></td>
   </tr>
 </table>
 
 Usage
 -----
 #### osl-postfix::default
-TODO: Write usage instructions for each cookbook.
+Include `osl-postfix::default` for hosts that only need to be able to send mail (functioning as a
+postfix client).
 
-e.g.
-Just include `osl-postfix` in your node's `run_list`:
-
-```json
-{
-  "name":"my_node",
-  "run_list": [
-    "recipe[osl-postfix]"
-  ]
-}
-```
+#### osl-postfix::server
+Include `osl-postfix::server` for hosts that will send and receive mail (functioning as a postfix
+server).
 
 Contributing
 ------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,16 @@
+default['osl-postfix']['main'] = {}
+default['osl-postfix']['main']['myorigin'] = '$mydomain'
+default['osl-postfix']['main']['smtpd_use_tls'] = 'no'
+
+case node['network']['default_gateway']
+# We must use the submission port on these networks
+when '10.162.136.1', '128.193.126.193', '148.100.110.1'
+  default['osl-postfix']['main']['relayhost'] = '[smtp.osuosl.org]:587'
+  default['osl-postfix']['main']['smtp_use_tls'] = 'yes'
+  if node['platform_family'] == 'debian'
+    default['osl-postfix']['main']['smtp_tls_CAfile'] = '/etc/ssl/certs/ca-certificates.crt'
+  end
+else
+  default['osl-postfix']['main']['relayhost'] = '[smtp.osuosl.org]:25'
+  default['osl-postfix']['main']['smtp_use_tls'] = 'no'
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,20 +17,9 @@
 # limitations under the License.
 
 node.default['postfix']['mail_type'] = 'client'
-node.default['postfix']['main']['myorigin'] = '$mydomain'
-node.default['postfix']['main']['smtpd_use_tls'] = 'no'
 
-case node['network']['default_gateway']
-# We must use the submission port on these networks
-when '10.162.136.1', '128.193.126.193', '148.100.110.1'
-  node.default['postfix']['main']['relayhost'] = '[smtp.osuosl.org]:587'
-  node.default['postfix']['main']['smtp_use_tls'] = 'yes'
-  if node['platform_family'] == 'debian'
-    node.default['postfix']['main']['smtp_tls_CAfile'] = '/etc/ssl/certs/ca-certificates.crt'
-  end
-else
-  node.default['postfix']['main']['relayhost'] = '[smtp.osuosl.org]:25'
-  node.default['postfix']['main']['smtp_use_tls'] = 'no'
+node['osl-postfix']['main'].each do |key, value|
+  node.default['postfix']['main'][key] = value
 end
 
 include_recipe 'postfix'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -16,4 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+node['osl-postfix']['main'].each do |key, value|
+  node.default['postfix']['main'][key] = value
+end
+
 include_recipe 'postfix::server'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -45,8 +45,12 @@ describe 'osl-postfix::default' do
           end
         end
       end
-      it do
-        expect(chef_run).to include_recipe 'postfix'
+      %w(
+        postfix::default
+      ).each do |recipe|
+        it do
+          expect(chef_run).to include_recipe recipe
+        end
       end
     end
   end

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -13,8 +13,12 @@ describe 'osl-postfix::server' do
         expect { chef_run }.to_not raise_error
       end
 
-      it do
-        expect(chef_run).to include_recipe 'postfix::server'
+      %w(
+        postfix::server
+      ).each do |recipe|
+        it do
+          expect(chef_run).to include_recipe recipe
+        end
       end
 
       it do


### PR DESCRIPTION
Using this attribute to populate node['postfix']['main'] makes it
much easier to override the postfix configuration that we set in
osl-posfix::default through the base_managed role (without having to
place recipes in the run_list before the role).

For added context, this was added specifically to address https://github.com/osuosl-cookbooks/proj-phpbb/pull/242#discussion_r259934255