### PR TITLE
Use hostname for myorigin by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@ default['osl-postfix']['main'] = {}
 default['osl-postfix']['main']['compatibility_level'] = '2' if platform_version >= 8
 default['osl-postfix']['main']['lmtp_tls_mandatory_protocols'] = osl_postfix_tls_protocols.join(',')
 default['osl-postfix']['main']['lmtp_tls_protocols'] = osl_postfix_tls_protocols.join(',')
-default['osl-postfix']['main']['myorigin'] = '$mydomain'
+default['osl-postfix']['main']['myorigin'] = '$myhostname'
 default['osl-postfix']['main']['smtp_tls_ciphers'] = 'high'
 default['osl-postfix']['main']['smtp_tls_exclude_ciphers'] = osl_postfix_tls_exclude_ciphers.join(',')
 default['osl-postfix']['main']['smtp_tls_mandatory_protocols'] = osl_postfix_tls_protocols.join(',')

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-postfix
 # Recipe:: default
 #
-# Copyright:: 2018-2023, Oregon State University
+# Copyright:: 2018-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-postfix
 # Recipe:: server
 #
-# Copyright:: 2018-2023, Oregon State University
+# Copyright:: 2018-2024, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -14,7 +14,7 @@ describe 'osl-postfix::default' do
       end
       [
         '# Configured as client',
-        'myorigin = $mydomain',
+        'myorigin = $myhostname',
         'relayhost = [smtp.osuosl.org]:25',
         'smtp_use_tls = no',
       ].each do |line|

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -2,7 +2,7 @@ smtpd_tls_security_level = input('smtpd_tls_security_level')
 
 control 'postfix-default' do
   describe ini '/etc/postfix/main.cf' do
-    its('myorigin') { should match '$mydomain' }
+    its('myorigin') { should match '$myhostname' }
     its('relayhost') { should match '[smtp.osuosl.org]:25' }
     its('smtpd_use_tls') { should match 'no' }
     its('smtp_use_tls') { should match 'no' }

--- a/test/integration/server/controls/server_spec.rb
+++ b/test/integration/server/controls/server_spec.rb
@@ -11,7 +11,7 @@ control 'postfix-server' do
   describe postfix_conf do
     its('lmtp_tls_mandatory_protocols') { should cmp tls_protocols }
     its('lmtp_tls_protocols') { should cmp tls_protocols }
-    its('myorigin') { should cmp '$mydomain' }
+    its('myorigin') { should cmp '$myhostname' }
     its('smtpd_tls_ciphers') { should cmp 'high' }
     its('smtpd_tls_eecdh_grade') { should cmp 'strong' }
     its('smtpd_tls_exclude_ciphers') { should cmp exclude_ciphers }


### PR DESCRIPTION
This should hopefully fix some issues with DMARC with cron email

Signed-off-by: Lance Albertson <lance@osuosl.org>
