### PR TITLE
Test Kitchen Config Refactor

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -28,4 +28,4 @@ platforms:
   - name: debian-12
     driver:
       image: dokken/debian-12
-      pid_one_command: /usr/lib/systemd/systemd
+      pid_one_command: /bin/systemd

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,0 +1,31 @@
+---
+driver:
+  name: dokken
+  privileged: true  # because Docker and SystemD/Upstart
+  chef_image: cincproject/cinc
+  chef_version: <%= ENV['CHEF_VERSION'] || '18' %>
+  pull_chef_image: false
+  pull_platform_image: false
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+  product_name: cinc
+  enforce_idempotency: true
+  chef_binary: /opt/cinc/bin/cinc-client
+
+platforms:
+  - name: almalinux-8
+    driver:
+      image: dokken/almalinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: almalinux-9
+    driver:
+      image: dokken/almalinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+  - name: debian-12
+    driver:
+      image: dokken/debian-12
+      pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.openstack.yml
+++ b/kitchen.openstack.yml
@@ -1,0 +1,40 @@
+---
+driver:
+  name: openstack
+  openstack_username: <%= ENV['OS_USERNAME'] %>
+  openstack_api_key: <%= ENV['OS_PASSWORD'] %>
+  openstack_auth_url: <%= ENV['OS_AUTH_URL'] %>
+  openstack_domain_id: 'default'
+  openstack_project_name: <%= ENV['OS_PROJECT_NAME'] %>
+  openstack_domain_name: <%= ENV['OS_USER_DOMAIN_NAME'] %>
+  floating_ip_pool: <%= ENV['OS_FLOATING_IP_POOL'] %>
+  network_ref: <%= ENV['OS_NETWORK_REF']  %>
+  flavor_ref: <%= ENV['OS_FLAVOR_REF'] %>
+  availability_zone: <%= ENV['OS_AVAILABILITY_ZONE'] || 'nova' %>
+  private_key_path: <%= ENV['OS_PRIVATE_SSH_KEY'] %>
+  key_name: <%= ENV['OS_SSH_KEYPAIR'] %>
+
+transport:
+  name: rsync
+  ssh_key: <%= ENV['OS_PRIVATE_SSH_KEY'] %>
+
+platforms:
+  - name: almalinux-8
+    driver_plugin: openstack
+    driver_config:
+      image_ref: "AlmaLinux 8"
+    transport:
+      username: almalinux
+  - name: almalinux-9
+    driver_plugin: openstack
+    driver_config:
+      image_ref: "AlmaLinux 9"
+    transport:
+      username: almalinux
+  - name: debian-12
+    driver_plugin: openstack
+    driver_config:
+      image_ref: "Debian 12"
+    transport:
+      username: debian
+

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,6 +1,17 @@
 ---
+driver:
+  name: vagrant
+
+verifier:
+  name: inspec
+
+transport:
+  name: rsync
+
 provisioner:
-  name: chef_zero
+  name: chef_infra
+  product_name: cinc
+  product_version: '18'
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true
@@ -10,8 +21,11 @@ provisioner:
     osl-selinux:
       enforcing: true
 
-verifier:
-  name: inspec
+platforms:
+  - name: almalinux-8
+  - name: almalinux-9
+  - name: debian-12
+
 suites:
   - name: default
     run_list:

--- a/test/integration/server/controls/server_spec.rb
+++ b/test/integration/server/controls/server_spec.rb
@@ -1,3 +1,4 @@
+docker = inspec.file('/.dockerenv').exist?
 tls_protocols = '!SSLv2,!SSLv3,!TLSv1,!TLSv1.1'
 exclude_ciphers = 'EXP,MEDIUM,LOW,DES,3DES,SSLv2'
 cipherlist = 'kEECDH:+kEECDH+SHA:kEDH:+kEDH+SHA:+kEDH+CAMELLIA:kECDH:+kECDH+SHA:kRSA:+kRSA+SHA:+kRSA+CAMELLIA:!aNULL:!eNULL:!SSLv2:!RC4:!MD5:!DES:!EXP:!SEED:!IDEA:!3DES'
@@ -31,7 +32,7 @@ control 'postfix-server' do
 
   describe iptables do
     it { should have_rule('-A smtp -p tcp -m tcp --dport 25 -j ACCEPT') }
-  end
+  end unless docker
 
   describe package 'postfix-perl-scripts' do
     it { should be_installed }


### PR DESCRIPTION
All tests green except with vagrant in:
* `default-debian-12`: apt-get issues. Manually needs an `apt-get update` to operate.
* `server`, `server-ssl`: Baseline verification error. Might be possible to add in an exception to not do the baseline test on Vagrant.