### PR TITLE
Bump postfix to ~> 7.0.3 for the alias database rebuild fix

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ version          '3.0.0'
 
 depends          'osl-firewall'
 depends          'osl-selinux'
-depends          'postfix', '~> 7.0.0'
+depends          'postfix', '~> 7.0.3'
 
 supports         'almalinux', '~> 8.0'
 supports         'almalinux', '~> 9.0'


### PR DESCRIPTION
postfix 7.0.0–7.0.2 never ran `newaliases` when Chef rewrote `/etc/aliases`: the aliases `postfix_map` set `postmap false`, which disabled the update execute and its template notification, so the compiled alias DB went stale silently and mail to newly added aliases bounced while converges looked green (observed on the mailrelay 2026-08-05). Fixed upstream in [sous-chefs/postfix#242](https://github.com/sous-chefs/postfix/pull/242), released as 7.0.3.

- Raise the dependency floor from `~> 7.0.0` to `~> 7.0.3` so resolution can never land on an affected version
- All 185 ChefSpec examples pass against postfix 7.0.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)